### PR TITLE
Update lambda function to use python3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Create a zip file of the code.
 
 ```bash
 zip code.zip s3apt.py config.py
-(cd venv/lib/python3.6/site-packages/ ; zip -r ../../../../code.zip *)
+(cd venv/lib/python3.9/site-packages/ ; zip -r ../../../../code.zip *)
 ```
 
 Create a new lambda in the AWS Console, and upload the zip file.

--- a/lambda-publish.sh
+++ b/lambda-publish.sh
@@ -6,4 +6,4 @@ zip  code.zip s3apt.py config.py
 
 (cd venv/lib/python3.9/site-packages/ ; zip -r ../../../../code.zip *)
 
-aws lambda update-function-code --function-name apt_repo_sync --zip-file fileb://./code.zip --publish
+aws lambda update-function-code --function-name s3apt_repo_maintainer --zip-file fileb://./code.zip --publish

--- a/lambda-publish.sh
+++ b/lambda-publish.sh
@@ -4,6 +4,6 @@
 rm code.zip
 zip  code.zip s3apt.py config.py
 
-(cd venv/lib/python2.7/site-packages/ ; zip -r ../../../../code.zip *)
+(cd venv/lib/python3.9/site-packages/ ; zip -r ../../../../code.zip *)
 
 aws lambda update-function-code --function-name apt_repo_sync --zip-file fileb://./code.zip --publish


### PR DESCRIPTION
I made a venv with Python3.9 and changed lambda-publish.sh to use the python3.9 packages.
If my understanding is correct then when I run lambda-publish.sh, AWS will update our lambda function to use the new Python code. In the past they upgraded from Python2.7 to Python3.6. The PRs for that are [here](https://github.com/path-robotics/s3apt/commit/1419f643c7b3083be2992dfbe2a0668a44d99a4d) and [here](https://github.com/path-robotics/s3apt/commit/ace6a8ac83cedf0ee453da4503b23418a0e2399a). More info about creating a lambda function with a virtual environment is [here](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-update-venv). 

I am going to wait until this is merged to run the upload script. Don't want to be that guy who breaks other people's playbook runs :sweat_smile: 

Below is how I setup the environment on my machine. 

1. Install Python3.9 and its venv
```sudo apt install software-properties-common
sudo add-apt-repository ppa:deadsnakes/ppa
sudo apt install python3.9
sudo apt install python3.9-venv
```
2. Create Python3.9 venv
```
python3.9 -m venv ./venv
```
3. Setup config.py with the APT_REPO_BUCKET_NAME = "path-apt-repo"
4. Activate the Python venv ```source venv/bin/activate```
5. Install packages into the virtual environment ```pip install -r requirements.txt```
6. Deactivate venv ```deactivate```