### PR TITLE
Update python-debian dependency to the latest to support zstd compression of .deb archives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ futures==3.1.1
 idna==3.10
 jmespath==0.9.5
 python-dateutil==2.8.1
-python-debian==0.1.36
+python-debian==1.0.1
 requests==2.32.5
 s3transfer==0.13.1
 six==1.16.0


### PR DESCRIPTION
The [API](https://python-debian-team.pages.debian.net/python-debian/html/api/debian.arfile.html) for the `debian.arfile.ArFile` [class that we use](https://github.com/path-robotics/s3apt/blob/677cc969aa844518acd841a8fb37465932689b03/s3apt.py#L42) is the same from version 0.1.36 to version 1.0.1:

* the first argument to the [constructor](https://python-debian-team.pages.debian.net/python-debian/html/api/debian.arfile.html#debian.arfile.ArFile) is a `str | Path` pointing at the debian archive
    * matches [what we do](https://github.com/path-robotics/s3apt/blob/677cc969aa844518acd841a8fb37465932689b03/s3apt.py#L42)
* the `ArFile.getnames()` [function](https://python-debian-team.pages.debian.net/python-debian/html/api/debian.arfile.html#debian.arfile.ArFile.getnames) takes no arguments and returns a list of strings
    * appears to match [how we use it](https://github.com/path-robotics/s3apt/blob/677cc969aa844518acd841a8fb37465932689b03/s3apt.py#L44)
* the `ArFile.getmember()` [function](https://python-debian-team.pages.debian.net/python-debian/html/api/debian.arfile.html#debian.arfile.ArFile.getmember) takes a `str` and returns an `ArMember` ([our usage](https://github.com/path-robotics/s3apt/blob/677cc969aa844518acd841a8fb37465932689b03/s3apt.py#L45) of that function), which we then [pass to tarfile.open()](https://github.com/path-robotics/s3apt/blob/677cc969aa844518acd841a8fb37465932689b03/s3apt.py#L47) as the `fileobj` argument
    * this jives with what the [docs](https://python-debian-team.pages.debian.net/python-debian/html/api/debian.arfile.html#debian.arfile.ArMember) say about the `ArMember` class:
        > Member of an ar archive.
        >
        > Implements most of a file object interface: read, readline, next, readlines, seek, tell, close.