### PR TITLE
Couple of clerical changes, and update lambda-publish.sh to say 3.14 instead of 3.9

### DIFF
--- a/lambda-publish.sh
+++ b/lambda-publish.sh
@@ -2,8 +2,8 @@
 
 # This script will upload a new version of the lambda
 rm code.zip
-zip  code.zip s3apt.py config.py
+zip code.zip s3apt.py config.py
 
-(cd venv/lib/python3.9/site-packages/ ; zip -r ../../../../code.zip *)
+(cd venv/lib/python3.14/site-packages/ ; zip -r ../../../../code.zip *)
 
 aws lambda update-function-code --function-name s3apt_repo_maintainer --zip-file fileb://./code.zip --publish

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ certifi==2025.8.3
 chardet==5.0.0
 charset-normalizer==3.4.3
 docutils==0.15.2
-futures==3.1.1
 idna==3.10
 jmespath==0.9.5
 python-dateutil==2.8.1

--- a/s3apt.py
+++ b/s3apt.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import config
 import json
 import urllib


### PR DESCRIPTION
The Lambda runtime has already been updated to 3.14, and this updated code has been deployed.